### PR TITLE
Added support for android_channel_id (Android 8 feature)

### DIFF
--- a/FcmSharp/FcmSharp/Requests/Notification/NotificationPayload.cs
+++ b/FcmSharp/FcmSharp/Requests/Notification/NotificationPayload.cs
@@ -35,6 +35,9 @@ namespace FcmSharp.Requests.Notification
 
         [JsonProperty("click_action")]
         public string ClickAction { get; set; }
+        
+        [JsonProperty("subtitle")]
+        public string Subtitle { get; set; }
 
         [JsonProperty("body_loc_key")]
         public string BodyLocKey { get; set; }

--- a/FcmSharp/FcmSharp/Requests/Notification/NotificationPayload.cs
+++ b/FcmSharp/FcmSharp/Requests/Notification/NotificationPayload.cs
@@ -14,6 +14,9 @@ namespace FcmSharp.Requests.Notification
 
         [JsonProperty("body")]
         public string Body { get; set; }
+        
+        [JsonProperty("android_channel_id")]
+        public string AndroidChannelId { get; set; };
 
         [JsonProperty("icon")]
         public string Icon { get; set; }


### PR DESCRIPTION
Added support for the new field 'android_channel_id' for notifications.
Added supprt for the new field 'subtitle' for ios notifications.

https://firebase.google.com/docs/cloud-messaging/http-server-ref#notification-payload-support#table2