### PR TITLE
Add permission denied for TopicManagementResponse

### DIFF
--- a/FcmSharp/FcmSharp/Responses/Converters/TopicErrorEnumConverter.cs
+++ b/FcmSharp/FcmSharp/Responses/Converters/TopicErrorEnumConverter.cs
@@ -27,6 +27,8 @@ namespace FcmSharp.Responses.Converters
                     return TopicManagementResponse.Error.Internal;
                 case "TOO_MANY_TOPICS":
                     return TopicManagementResponse.Error.TooManyTopics;
+                case "PERMISSION_DENIED":
+                    return TopicManagementResponse.Error.PermissionDenied;
                 default:
                     return TopicManagementResponse.Error.Unknown;
             }

--- a/FcmSharp/FcmSharp/Responses/TopicMessageResponse.cs
+++ b/FcmSharp/FcmSharp/Responses/TopicMessageResponse.cs
@@ -14,7 +14,8 @@ namespace FcmSharp.Responses
             InvalidArgument,
             NotFound,
             Internal,
-            TooManyTopics
+            TooManyTopics,
+            PermissionDenied
         }
         
         public class ResultItem


### PR DESCRIPTION
There is script to subscribe token to topic.
If token is given from another fcm project, then result of subscription is permission denied, but current implementation gives the result of subscription is unknown.