### PR TITLE
Rename serialize the collapse key as collapseKey

### DIFF
--- a/FcmSharp/FcmSharp/Requests/AndroidConfig.cs
+++ b/FcmSharp/FcmSharp/Requests/AndroidConfig.cs
@@ -10,8 +10,15 @@ namespace FcmSharp.Requests
 {
     public class AndroidConfig
     {
-        [JsonProperty("collapse_key")]
+        [JsonProperty("collapseKey")]
         public string CollapseKey { get; set; }
+
+        [JsonProperty("collapse_key")]
+        public string CollapseKeyLegacy
+        {
+            get { return CollapseKey; }
+            set { CollapseKey = value; }
+        }
 
         [JsonProperty("priority")]
         [JsonConverter(typeof(AndroidMessagePriorityEnumConverter))]


### PR DESCRIPTION
The collapse key should be `collapseKey` according to https://firebase.google.com/docs/cloud-messaging/concept-options#collapsible_and_non-collapsible_messages

But it also states that it should be "collapse_key in legacy protocols (all platforms)", I have no idea what this means, so I added a property such that `collapse_key` is also included in the request.